### PR TITLE
Fix GitHub Actions workflow for uv without lock file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Lint with flake8
       run: |
-        uv pip install flake8
+        uv pip install flake8 --system
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings
@@ -40,7 +40,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        uv run pytest test_cli.py test_github_similarity_service.py -v --cov=. --cov-report=xml --cov-report=term-missing
+        pytest test_cli.py test_github_similarity_service.py -v --cov=. --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,15 @@ jobs:
       uses: astral-sh/setup-uv@v3
       with:
         version: "latest"
-        enable-cache: true
+        enable-cache: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      run: uv python install ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv pip install -r requirements-test.txt
+      run: uv pip install -r requirements-test.txt --system
 
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
- Disable enable-cache to avoid uv.lock requirement
- Use actions/setup-python for Python installation
- Add --system flag to uv pip install for global environment
- Maintains uv speed benefits without requiring uv.lock file